### PR TITLE
Fixed package restore and publish

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,6 +49,8 @@ jobs:
         dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
     - name: Create NuGet package
       run: dotnet pack --no-build --output ./nuget-packages
     - name: Publish to NuGet

--- a/src/Host.Console/Host.Console.csproj
+++ b/src/Host.Console/Host.Console.csproj
@@ -5,8 +5,6 @@
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PublishSingleFile>true</PublishSingleFile>
-        <SelfContained>true</SelfContained>
         <OutputType>Exe</OutputType>
         <IsPackable>true</IsPackable>
         <PackAsTool>true</PackAsTool>
@@ -19,7 +17,7 @@
         <Description>Your Open Source Software (OSS) tool to do a comprehensive dependency analysis for licenses and vulnerabilities. Scrutinize is a powerful and extensible tool designed to scan and analyze software projects utilizing npm and NuGet for their dependencies.</Description>
         <Copyright>Copyright (c) RobertvBraam 2023</Copyright>
         <PackageProjectUrl>https://github.com/RobertvBraam/Scrutinize</PackageProjectUrl>
-        <PackageLicenseUrl>https://licenses.nuget.org/AGPL-3.0-or-later</PackageLicenseUrl>
+        <license>AGPL-3.0-or-later</license>
         <RepositoryUrl>https://github.com/RobertvBraam/Scrutinize</RepositoryUrl>
         <PackageTags>security, dependencies, license, vulnerability, npm, nuget, console, ci-cd</PackageTags>
         <PackageId>Scrutinize</PackageId>


### PR DESCRIPTION
- Added a build command to the pipeline
- Updated the license to the new format
- Removed illegal nuget setting in combination with a dotnet tool